### PR TITLE
Fix typo in default function arguments

### DIFF
--- a/src/data/index.js
+++ b/src/data/index.js
@@ -28,7 +28,7 @@ const data = [
     slug: 'default-function-arguments',
     info: 'Sets the default argument if nothing is passed in.',
     code:
-      'multiply = (a, b = 1) {\n return a * b;\n}\nconsole.log(multiply(5));\n// Expected output: 5\nconsole.log(multiply(5, 3));\n// Expected output: 15',
+      'multiply = (a, b = 1) => {\n return a * b;\n}\nconsole.log(multiply(5));\n// Expected output: 5\nconsole.log(multiply(5, 3));\n// Expected output: 15',
   },
   {
     category: 'Template Strings',


### PR DESCRIPTION
If it is an arrow function there must be an arrow