### PR TITLE
feat(data/index.js): Add `Map` global object snippet

### DIFF
--- a/src/data/index.js
+++ b/src/data/index.js
@@ -140,9 +140,9 @@ const data = [
     title: 'Map, Map.set(), Map.get(), Map.size()',
     slug: 'global-objects-map',
     info:
-      'Map, not to be confused with Array.prototype.map, holds key-value pairs. While Map\'s and object-literals have their similarities, they also have some key differences.',
+      'Map, not to be confused with Array.prototype.map(), holds key-value pairs. While Map\'s and object-literals have their similarities, they also have some key differences.',
     code:
-      'const myMap = new Map(); // creates a new instance of a Map object\nconst keyObj = {};\n\nconsole.log(myMap); // Map(0) {}\n\n// unlike object-literals, a Maps keys/values can be anything\nmyMap.set(\'string\', \'they can be strings\')\nmyMap.set(1, \'or integers\')\nmyMap.set(true, \'...booleans\')\nmyMap.set(keyObj, \'even objects?\')\n\nconsole.log(myMap.size) // 4\n\nmyMap.get(keyObj) // "even objects?"',
+      'const myMap = new Map(); // creates a new instance of a Map object\nconst keyObj = {};\n\nconsole.log(myMap); // Map(0) {}\n\n// unlike object-literals, a Map\'s keys/values can be anything\nmyMap.set(\'string\', \'they can be strings\')\nmyMap.set(1, \'or integers\')\nmyMap.set(true, \'...booleans\')\nmyMap.set(keyObj, \'even objects?\')\n\nconsole.log(myMap.size) // 4\n\nmyMap.get(keyObj) // "even objects?"',
   },
 ];
 

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -135,6 +135,15 @@ const data = [
     code:
       'function multiply(rate, ...numbers) {\n return numbers.map(number => number * rate);\n}\n\nconsole.log(multiply(2, 10, 20, 30));\n// 20, 40, 60',
   },
+  {
+    category: 'Global Objects',
+    title: 'Map, Map.set(), Map.get(), Map.size()',
+    slug: 'global-objects-map',
+    info:
+      'Map, not to be confused with Array.prototype.map, holds key-value pairs. While Map\'s and object-literals have their similarities, they also have some key differences.',
+    code:
+      'const myMap = new Map(); // creates a new instance of a Map object\nconst keyObj = {};\n\nconsole.log(myMap); // Map(0) {}\n\n// unlike object-literals, a Maps keys/values can be anything\nmyMap.set(\'string\', \'they can be strings\')\nmyMap.set(1, \'or integers\')\nmyMap.set(true, \'...booleans\')\nmyMap.set(keyObj, \'even objects?\')\n\nconsole.log(myMap.size) // 4\n\nmyMap.get(keyObj) // "even objects?"',
+  },
 ];
 
 export default data;


### PR DESCRIPTION
ref #1 

### Feature Name
Add `Map` global object snippet

### Category
Snippets

### Info
```
This feature adds in a small explanation of how to get started using the `Map` global object.
```

### Example
![es6-map-full](https://user-images.githubusercontent.com/29239201/40591627-a8926c02-61e2-11e8-98a4-5b9d8cee35b0.jpg)
